### PR TITLE
Zpracování poplatků dohromady s ostatními transakcemi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ eggs
 .project
 .pydevproject
 *.sublime*
+.vscode/


### PR DESCRIPTION
Když je v transakci poplatek, tak se stejně jako předtím vytvoří nový řádek jakoby pro CSV soubor. Nezapíše se ale do souboru, ale rovnou se rekurzivně zpracuje a zařadí mezi ostatní normální transakce. Inspiroval jsem se funkcionalitou třídy `StatementParser` a její metodou `parse`.

Obsahuje také drobné změny, které dělají kód snad čitelnější.

Na začátku souboru `airbankcz.py` stále ještě zůstaly nějaké zmínky o souboru poplatků. Nechal jsem to tam, ale odhadoval bych, že se to může prostě smazat. Detailně jsem to však nestudoval.